### PR TITLE
Add automated Windows builds with AppVeyor

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# xvc codec
+# xvc codec [![AppVeyor Build Status](https://ci.appveyor.com/api/projects/status/github/divideon/xvc?branch=master&svg=true)](https://ci.appveyor.com/project/divideon/xvc)
 
 The xvc codec is a next-generation software-defined video compression format, built using
 world-class compression technologies.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,8 +5,6 @@ environment:
   matrix:
    - target: x64
      xvc_target: "x86_64"
-   - target: Arm64
-     xvc_target: "^arm64"
 
 before_build: 
  - SET XVC_TARGET_ARCH=%xvc_target%
@@ -23,7 +21,7 @@ deploy:
   - provider: GitHub
     artifact: $(APPVEYOR_PROJECT_NAME)-$(target)
     auth_token:
-      secure: 'hY5Mk6KOwgQ97TzEBsM7Woqr1ZIm5QTvHg8EvxMV1x8j3wk/3mNBMqWFFbEIBK0i'
+      secure: 'crYJW1VEBGF+La21YHoo9EO28nF55K0FyvVMeWwMBjf0JSyhGSuY1VUowmYyikGt'
     prerelease: true
     on:
       appveyor_repo_tag: true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,7 +16,7 @@ build:
   project: xvc.sln
   
 artifacts:
-    - path: $(target)\Release\*.*
+    - path: app\Release\*.*
       name: $(APPVEYOR_PROJECT_NAME)-$(target)
 
 deploy:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,29 @@
+image: Visual Studio 2017
+configuration: Release
+
+environment:
+  matrix:
+   - target: x64
+     xvc_target: "x86_64"
+   - target: Arm64
+     xvc_target: "^arm64"
+
+before_build: 
+ - SET XVC_TARGET_ARCH=%xvc_target%
+ - cmake . -A %target%
+
+build:
+  project: xvc.sln
+  
+artifacts:
+    - path: $(target)\Release\*.*
+      name: $(APPVEYOR_PROJECT_NAME)-$(target)
+
+deploy:
+  - provider: GitHub
+    artifact: $(APPVEYOR_PROJECT_NAME)-$(target)
+    auth_token:
+      secure: 'hY5Mk6KOwgQ97TzEBsM7Woqr1ZIm5QTvHg8EvxMV1x8j3wk/3mNBMqWFFbEIBK0i'
+    prerelease: true
+    on:
+      appveyor_repo_tag: true


### PR DESCRIPTION
This PR adds an AppVeyor configuration that produces automated Windows builds using Visual Studio 2017. 

For optimal integration AppVeyor needs to be [enabled](https://github.com/marketplace/appveyor) on the GitHub marketplace.

Sample AppVeyor runs can be viewed [here](https://ci.appveyor.com/project/EwoutH/xvc/history). `xvcdec.exe` and `xvcenc.exe` can be found under the Artifacts-tab of each job of each build and a test release on GitHub can be viewed [here](https://github.com/EwoutH/xvc/releases/tag/v2.1-test).

![screenshot_390](https://user-images.githubusercontent.com/15776622/52955040-f5dec980-338b-11e9-9223-d53936ce1578.png)

There are a few issues I can't seem to fix:

1. When running `cmake . -A %target%` cmake keeps reporting `-- xvc target architecture: x86` ([line 24](https://ci.appveyor.com/project/EwoutH/xvc/build/job/s954edvkd5cmemf6#L24) on AppVeyor). I tried setting the `XVC_TARGET_ARCH` variable to `^arm64` or `x86_64` in the `appveyor.yml`, but it doesn't seem to work.
2. The Arm64 builds crash on various errors, probably because of the above issue.