### PR TITLE
Add Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,19 @@
+language: cpp
+dist: xenial
+
+addons:
+  apt:
+    packages:
+     - cmake
+
+script:
+ - cmake .
+ - make
+
+jobs:
+  include:
+    - name: "Linux GCC"
+    - name: "Linux Clang"
+      compiler: clang
+    - name: "macOS GCC"
+      os: osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ addons:
 script:
  - cmake .
  - make
+ - make test
 
 jobs:
   include:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# xvc codec [![AppVeyor Build Status](https://ci.appveyor.com/api/projects/status/github/divideon/xvc?branch=master&svg=true)](https://ci.appveyor.com/project/divideon/xvc)
+# xvc codec [![AppVeyor Build Status](https://ci.appveyor.com/api/projects/status/github/divideon/xvc?branch=master&svg=true)](https://ci.appveyor.com/project/divideon/xvc) [![Travis Build Status](https://travis-ci.org/divideon/xvc.svg?branch=master)](https://travis-ci.org/divideon/xvc)
 
 The xvc codec is a next-generation software-defined video compression format, built using
 world-class compression technologies.


### PR DESCRIPTION
Adds continuous integration on Linux & macOS with both GCC and Clang compilers. For optimal integration with GitHub, Travis CI needs to be [enabled](https://github.com/marketplace/travis-ci) on the GitHub marketplace.

**Edit:** Error was caused by the build process itself, fixed. @perher Ready to merge!