### PR TITLE
Fix Travis badge in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# xvc codec [![AppVeyor Build Status](https://ci.appveyor.com/api/projects/status/github/divideon/xvc?branch=master&svg=true)](https://ci.appveyor.com/project/divideon/xvc) [![Travis Build Status](https://travis-ci.org/divideon/xvc.svg?branch=master)](https://travis-ci.org/divideon/xvc)
+# xvc codec [![AppVeyor Build Status](https://ci.appveyor.com/api/projects/status/github/divideon/xvc?branch=master&svg=true)](https://ci.appveyor.com/project/divideon/xvc) [![Travis Build Status](https://travis-ci.com/divideon/xvc.svg?branch=master)](https://travis-ci.com/divideon/xvc)
 
 The xvc codec is a next-generation software-defined video compression format, built using
 world-class compression technologies.


### PR DESCRIPTION
Small update in README.md (switch travis-ci.org to travis-ci.com).

Also, with Travis only `xvc_test` is now running, do you also want the `googletest` to run?