### PR TITLE
Travis: Use matrix and add ccache and use newer images

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,10 +9,20 @@ os:
   - linux
   - osx
 
+addons:
+  homebrew:
+    packages: ccache
+
+env:
+  matrix:
+    - build_type=Release
+    - build_type=Debug
+    - build_type=Release build_shared=ON
+
 script:
   - mkdir build && cd build
-  - cmake ..
-  - make
+  - cmake .. -DCMAKE_{C,CXX}_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE=${build_type:-Release} -DBUILD_SHARED_LIBS=${build_shared:-OFF}
+  - make -j 8
   - make test
   - sudo make install
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,21 +1,22 @@
 language: cpp
-dist: xenial
-
-addons:
-  apt:
-    packages:
-     - cmake
+cache: ccache
+dist: bionic
+osx_image: xcode11
+compiler:
+  - gcc
+  - clang
+os:
+  - linux
+  - osx
 
 script:
- - mkdir build && cd build
- - cmake ..
- - make
- - make test
+  - mkdir build && cd build
+  - cmake ..
+  - make
+  - make test
+  - sudo make install
 
-jobs:
-  include:
-    - name: "Linux GCC"
-    - name: "Linux Clang"
-      compiler: clang
-    - name: "macOS GCC"
-      os: osx
+matrix:
+  exclude:
+    - os: osx
+      compiler: gcc


### PR DESCRIPTION
Doesn't actually change much since it creates the same jobs, just allows for easier expansion in the future

- Upgrade the linux image to Bionic
- Use xcode11 image
- Add ccache to cache the builds for faster builds
  - Slow for the first time building, speeds up successive compilations
- Add install command to test installing