### PR TITLE
src/xvc_common_lib/transform_data.h: Include cstdint

### DIFF
--- a/src/xvc_common_lib/transform_data.h
+++ b/src/xvc_common_lib/transform_data.h
@@ -22,6 +22,7 @@
 #ifndef XVC_COMMON_LIB_TRANSFORM_DATA_H_
 #define XVC_COMMON_LIB_TRANSFORM_DATA_H_
 
+#include <cstdint>
 #include <array>
 
 namespace xvc {


### PR DESCRIPTION
mingw-w64 gcc 10 fails without it


Fixes #20